### PR TITLE
Commandline options

### DIFF
--- a/shortcuts/clearSystemShortcuts.py
+++ b/shortcuts/clearSystemShortcuts.py
@@ -121,7 +121,7 @@ def get_idea_key_strokes():
 
 def get_system_config_from_gsettings():
     gsettings_output = subprocess.run(
-        "gsettings list-recursively",
+        'gsettings list-recursively | grep -v -E "\[\s*\]"',
         shell=True,
         stdout=subprocess.PIPE,
         universal_newlines=True


### PR DESCRIPTION
This PR add commandline interface for script:
```
python3 clearSystemShortcuts.py -h                                                                         commandline_options     0.0361   
usage: clearSystemShortcuts.py [-h] [-v] [-e]

optional arguments:
  -h, --help     show this help message and exit
  -v, --verbose  print more information
  -e, --execute  remove/replace shortcuts conflicting to IntellIJ IDEA
```

