### PR TITLE
Add cargo to terminal-tools

### DIFF
--- a/playbooks/terminal-tools.yml
+++ b/playbooks/terminal-tools.yml
@@ -22,6 +22,7 @@
       - p7zip
       - lzip
       - lunzip
+      - cargo
     become: true
 
   - name: install exa if its binary does not exists

--- a/playbooks/utilities.yml
+++ b/playbooks/utilities.yml
@@ -7,7 +7,6 @@
     apt: name="{{packages}}" state=present
     vars:
       packages:
-      - cargo
       - python
       - python-pip
       - python3


### PR DESCRIPTION
Cargo is rust based package manager required to install some terminal
tools in playbook e.q. exa, tokei. Without cargo added playbook is
not working independently of other playbooks.